### PR TITLE
Robots.txt update - allow crawlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,17 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="google-site-verification" content="cs8fwj9aTjGLpM46_W8YIWiKla6dghAkTJUeRXXDZfQ" />
+
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-SJ8R8X2LRR"></script>
+	<script>
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
+
+	  gtag('config', 'G-SJ8R8X2LRR');
+	</script>
 
     <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <meta name="google-site-verification" content="cs8fwj9aTjGLpM46_W8YIWiKla6dghAkTJUeRXXDZfQ" />
 
 	<!-- Global site tag (gtag.js) - Google Analytics -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-SJ8R8X2LRR"></script>

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /
+Allow: /


### PR DESCRIPTION
-Robots.txt was blocking all the web crawlers including Google. Now updated, this good SEO practice will allow all crawlers for searchers indexing. 
After allow the crawlers the sitemap.xml will need to be sended.

-websearch code verification removed, no longer required 